### PR TITLE
add support for alternate contact form page

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress" namespace="WordPressCS\WordPress" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+	<rule ref="WordPress-Extra">
+		<exclude name="Generic.Formatting" />
+		<exclude name="Generic.WhiteSpace" />
+		<exclude name="Squiz.Strings" />
+		<exclude name="Generic.Files" />
+		<exclude name="WordPress.Files" />
+		<exclude name="WordPress.Arrays" />
+		<exclude name="Squiz.ControlStructures" />
+		<exclude name="Squiz.Strings.DoubleQuoteUsage" />
+		<exclude name="PSR2.ControlStructures" />
+		<exclude name="PEAR.Functions.FunctionCallSignature" />
+		<exclude name="Generic.Functions.FunctionCallArgumentSpacing" />
+		<exclude name="WordPress.PHP.YodaConditions.NotYoda" />
+		<exclude name="WordPress.PHP.StrictInArray" />
+		<exclude name="WordPress.PHP.StrictComparisons.LooseComparison" />
+		<exclude name="WordPress.NamingConventions" />
+		<exclude name="WordPress.WhiteSpace" />
+		<exclude name="Squiz.WhiteSpace" />
+		<exclude name="Squiz.PHP.CommentedOutCode.Found" />
+		<exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie" />
+		<exclude name="Generic.ControlStructures.InlineControlStructure.NotAllowed" />
+		<exclude name="PEAR.Files.IncludingFile.BracketsNotRequired" />
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax" />
+		<exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing" />
+		<exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing" />
+		<exclude name="WordPress.WhiteSpace.PrecisionAlignment.Found" />
+		<exclude name="Squiz.PHP.EmbeddedPhp.MultipleStatements" />
+		<exclude name="NormalizedArrays.Arrays.ArrayBraceSpacing.SpaceAfterArrayOpenerSingleLine" />
+		<exclude name="NormalizedArrays.Arrays.ArrayBraceSpacing.SpaceBeforeArrayCloserSingleLine" />
+		<exclude name="NormalizedArrays.Arrays.CommaAfterLast.MissingMultiLine" />
+        <exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />
+		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed" />
+		<exclude name="Universal.Operators.StrictComparisons.LooseEqual" />
+		<exclude name="Universal.Operators.StrictComparisons.LooseNotEqual" />
+		<exclude name="PSR2.Methods.FunctionClosingBrace.SpacingBeforeClose" />
+
+	</rule>
+
+	<rule ref="PHPCompatibility"/>
+
+	<config name="testVersion" value="7.4-8.2"/>
+</ruleset>

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === u3a-siteworks-contact-form ===
 Requires at least: 5.9
-Tested up to: 6.5
+Tested up to: 6.6
 Stable tag: 5.9
 Requires PHP: 7.4
 License: GPLv2 or later
@@ -35,6 +35,15 @@ You can also use this alternate form:
 When the shortcode is rendered, the plugin will create a nummeric code which is included in the link to the contact form.  
 This is checked by the contact form logic to avoid spammers targeting the form.
 The email address given in the shortcode never appears on the web page.
+
+There is a third parameter available for advanced users:
+* slug - the slug of the page that contains the u3a_contact_form
+
+Example:
+`[u3a_contact name="Freda Smith" slug="slug-of-page"]`
+
+This will override the default behaviour which is to use the page with the slug 'u3a-contact-form'.
+
 
 = u3a_contact_form shortcode =
 

--- a/u3a-siteworks-contact-form.php
+++ b/u3a-siteworks-contact-form.php
@@ -183,13 +183,15 @@ function u3a_contact_shortcode($atts, $content = null)
     }
 
     // handle a specific page slug if provided
-    $slug = trim($atts['slug'] ?? '');
+    $slug = sanitize_title(trim($atts['slug'] ?? ''));
     if (empty($slug)) {
         $slug = U3A_CONTACT_PAGE_SLUG;
     } else {
         // does the specified page slug exist?
         global $wpdb;
-        $slugfound = $wpdb->get_var("SELECT count(post_title) FROM $wpdb->posts WHERE post_name like '".$slug."'");
+        $slugfound = $wpdb->get_var(
+            $wpdb->prepare("SELECT count(post_title) FROM $wpdb->posts WHERE post_name like %s", $slug)
+        );
         if ($slugfound < 1) { // if not found, use the default
             $slug = U3A_CONTACT_PAGE_SLUG;
         }


### PR DESCRIPTION
Implements OP1071
Minor changes to the [u3a_contact] shortcode to allow a parameter "slug" to override the default page slug used for the contact form.  (Falls back to the default slug if the one given does not exist.

For a testbed illustrating how this is used with a "sub-site" install the 'Local' zip file wales.zip from https://u3a-llandrindod.org.uk/training/wales.zip